### PR TITLE
Reorganise the reading list groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,10 @@ If you'd like to make a suggestion for what to read, please do whatever you'd pr
 
 ## Reading list
 
-:white_check_mark: = we've read it
-
-📺 = Watching/Listening material
+- :white_check_mark: = we've read it
+- 📺 = Watching/Listening material
+- [1] = A longer piece of work, we'd need to choose a chapter or section.
+- [2] = A shorter piece of work, perhaps to combine with something else
 
 These are rough categories, reading materials appear once in the category we felt they fit best. 
 We welcome suggestions for new categories, or moving materials between categories (please [open an issue](https://github.com/very-good-science/data-ethics-club/issues/new), or [email us](mailto:grp-ethicaldatascience@groups.bristol.ac.uk)).
@@ -153,12 +154,6 @@ We welcome suggestions for new categories, or moving materials between categorie
 
 * [Explainable machine learning: how can you determine what a party knew or intended when a decision was made by machine-learning?](https://www.scl.org/articles/12130-explainable-machine-learning-how-can-you-determine-what-a-party-knew-or-intended-when-a-decision-was-made-by-machine-learning) - suggested by [Tom Whittaker](https://blog.burges-salmon.com/u/102g2vz/tom-whittaker)
 * [Explainable Artificial Intelligence (XAI): Concepts, taxonomies, opportunities and challenges toward responsible AI](https://www.sciencedirect.com/science/article/pii/S1566253519308103?casa_token=1cYbsG99NNAAAAAA:4FsE_4ZQI72ZSA-SbawjNiEkhY5zIDjChANdTKxJ8Qy8RiCCQ0ztFye-rdQ98MeO9RY3_8Nw) - suggested by [@NatalieThurlby](https://github.com/NatalieThurlby)
-
-
-
-### Key
-- [1]: A longer piece of work, we'd need to choose a chapter or section.
-- [2]: A shorter piece of work, perhaps to combine with something else
 
 ## Contributors ✨
 

--- a/README.md
+++ b/README.md
@@ -106,11 +106,12 @@ We welcome suggestions for new categories, or moving materials between categorie
 * [Artificial intelligence and transparency in the public sector](https://blog.burges-salmon.com/post/102gnvk/artificial-intelligence-and-transparency-in-the-public-sector) - suggested by [Tom Whittaker](https://blog.burges-salmon.com/u/102g2vz/tom-whittaker)
 
 * [Owning Ethics: Corporate Logics, Silicon Valley, and the Institutionalization of Ethics](https://muse.jhu.edu/article/732185) 
+* [GCHQ - Pioneering a New National Security: The Ethics of Artificial Intelligence](https://www.gchq.gov.uk/files/GCHQAIPaper.pdf) - suggested by [@ninadicara]((https://github.com/ninadicara))
 
 ### Research culture
 
 * [Towards Decolonising Computional Science](https://arxiv.org/abs/2009.14258) - suggested by [@nataliethurlby](https://github.com/NatalieThurlby)
-* 📺[Algorithmic Colonialisation](https://ethics.fast.ai/videos/?lesson=9) suggested by @ninadicara
+* 📺[Algorithmic Colonialisation](https://ethics.fast.ai/videos/?lesson=9) suggested by [@ninadicara]((https://github.com/ninadicara))
 
 * [#bropenscience is Broken Science](https://thepsychologist.bps.org.uk/volume-33/november-2020/bropenscience-broken-science) - suggested by [@nataliethurlby](https://github.com/NatalieThurlby)
 * [Collectors, Allies, and Nightlights, Oh My](https://www.wpcjournal.com/article/view/20275) - suggested by [@nataliethurlby](https://github.com/NatalieThurlby)

--- a/README.md
+++ b/README.md
@@ -45,42 +45,73 @@ If you'd like to make a suggestion for what to read, please do whatever you'd pr
 
 :white_check_mark: = we've read it
 
-### Suggestions for reading
+📺 = Watching/Listening material
+
 These are rough categories, reading materials appear once in the category we felt they fit best. 
 We welcome suggestions for new categories, or moving materials between categories (please [open an issue](https://github.com/very-good-science/data-ethics-club/issues/new), or [email us](mailto:grp-ethicaldatascience@groups.bristol.ac.uk)).
 
-#### Natural Language Processing
-* [On the Dangers of Stochastic Parrots: Can Language Models Be Too Big?](http://faculty.washington.edu/ebender/papers/Stochastic_Parrots.pdf) - suggested by [@ninadicara](https://github.com/ninadicara) - :white_check_mark: [17th February 2021](./meetings/2021/02-feb/17-02-21_meeting.md)
-* [Mitigating Gender Bias in Natural Language Processing: Literature Review](https://arxiv.org/abs/1906.08976) - suggested by [@NatalieThurlby](https://github.com/NatalieThurlby)
-* [Social Biases in NLP Models as Barriers for Persons with Disabilities](https://arxiv.org/pdf/2005.00813.pdf)
-* [Man is to Computer Programmer as Woman is to Homemaker? Debiasing Word Embeddings](https://arxiv.org/pdf/1607.06520.pdf) - suggested by [@leriomaggio](https://github.com/leriomaggio)
-   * Follow-up paper: [Lipstick on a Pig: Debiasing Methods Cover up Systematic Gender Biases in Word Embeddings But do not Remove Them](https://arxiv.org/abs/1903.03862) - suggested by [@NatalieThurlby](https://github.com/NatalieThurlby)
-* [Semantics derived automatically from language corpora contain human-like biases](https://science.sciencemag.org/content/sci/356/6334/183.full.pdf) - suggested by[@alicesaunders](https://github.com/alicesaunders)
-* [Gender Bias and Sexism in Language](https://oxfordre.com/communication/view/10.1093/acrefore/9780190228613.001.0001/acrefore-9780190228613-e-470#acrefore-9780190228613-e-470-bibItem-0028) - suggested by [@leriomaggio](https://github.com/leriomaggio)
+### What is data ethics?
 
-#### Algorithmic decision making
+* [Introduction to Research Ethics](https://the-turing-way.netlify.app/ethical-research/ethics-intro.html) - suggested by [@leriomaggio](https://github.com/leriomaggio)
+* [What is Data Ethics?](https://royalsocietypublishing.org/doi/10.1098/rsta.2016.0360)<sup>1</sup>
+* [Ethical data science](https://arxiv.org/pdf/1411.1373.pdf)<sup>1</sup>
+* [Algorithmic Injustices: Towards a relational ethics](https://arxiv.org/abs/1912.07376) - suggested by [@RobertArbon](https://github.com/RobertArbon), [:white_check_mark: 3rd March 2021](meetings/2021/03-march/03-03-21_meeting.md)
+
+* [Ethical principles in machine learning and artificial intelligence: cases from the field and possible ways forward](https://www.nature.com/articles/s41599-020-0501-9) 
+* [Ethics can't be a side hustle](https://deardesignstudent.com/ethics-cant-be-a-side-hustle-b9e78c090aee) - :white_check_mark: [3rd Feb 2021](./meetings/2021/02-feb/03-02-21_meeting.md)
+* [Reflections on trusting trust](http://users.ece.cmu.edu/~ganger/712.fall02/papers/p761-thompson.pdf)
+
+* 📺 [21 Fairness Definitions and their politics](https://www.youtube.com/watch?v=jIXIuYdnyyk) - suggested by [@NatalieThurlby](https://github.com/NatalieThurlby)
+
+* 📺 [AI, Ain’t I a Woman?](https://www.youtube.com/watch?v=HZxV9w2o0FM) - poem<sup>2</sup> - suggested by Valentina Ragni
+
+### The nature of data
+
+* [Why data is never raw](https://www.thenewatlantis.com/publications/why-data-is-never-raw)
+* [The Missing Datasets Project](https://github.com/MimiOnuoha/missing-datasets) - [#1](../../issues/1) - suggested by [@ninadicara](https://github.com/ninadicara)
+
+* [Dataism is our new God](https://onlinelibrary.wiley.com/doi/pdf/10.1111/npqu.12080?casa_token=cj8N7zTKYeIAAAAA:fiV6jUDL9dVhZ5oADoLszgzL5Ubn5NWCmLuO6mVxa_mf_sO-JEB6nU-9FP5fYL5pm8JisxYlWEe) - suggested by [@NatalieThurlby](https://github.com/NatalieThurlby)
+
+### Algorithmic decision making
+
 * [Review into bias in algorithmic decision making](https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/939109/CDEI_review_into_bias_in_algorithmic_decision-making.pdf)<sup>1</sup> - suggested by [@nataliethurlby](https://github.com/NatalieThurlby)
   * Suggested excerpt: [executive summary](https://github.com/very-good-science/data-ethics-club/blob/main/meetings/2021/jan/20-01-20_cdei_algorithmic_bias_summary.pdf) - [:white_check_mark: 20th January 2021](meetings/2021/01-jan/20-01-21_meeting.md)
-  * Related articles: 
-    * [Accountability for algorithms: a response to the CDEI review into bias in algorithmic decision-making](https://www.adalovelaceinstitute.org/blog/response-to-cdei-review-bias-algorithmic-decision-making/) - suggested by [Tom Whittaker](https://blog.burges-salmon.com/u/102g2vz/tom-whittaker)
-    * [Artificial intelligence and transparency in the public sector](https://blog.burges-salmon.com/post/102gnvk/artificial-intelligence-and-transparency-in-the-public-sector) - suggested by [Tom Whittaker](https://blog.burges-salmon.com/u/102g2vz/tom-whittaker)
+  * Related: [Accountability for algorithms: a response to the CDEI review into bias in algorithmic decision-making](https://www.adalovelaceinstitute.org/blog/response-to-cdei-review-bias-algorithmic-decision-making/) - suggested by [Tom Whittaker](https://blog.burges-salmon.com/u/102g2vz/tom-whittaker)
 * [Algorithms Of Oppression](https://safiyaunoble.com/research-writing/)<sup>1</sup> - suggested by [@mtwest2718](https://github.com/mtwest2718)
-    * Suggested excerpt: [Social Inequality Will Not Be Solved By An App](https://www.wired.com/story/social-inequality-will-not-be-solved-by-an-app/) 
+  * Suggested excerpt: [Social Inequality Will Not Be Solved By An App](https://www.wired.com/story/social-inequality-will-not-be-solved-by-an-app/) 
 * [Automating Inequality](https://virginia-eubanks.com/)<sup>1</sup> - suggested by Valentina Ragni and [@mtwest2718](https://github.com/mtwest2718)
-  * [A hippocratic oath for data science](https://virginia-eubanks.com/2018/02/21/a-hippocratic-oath-for-data-science/) - suggested by [@ninadicara](https://github.com/ninadicara)
   * [We created poverty, algorithms won't make that go away](https://www.theguardian.com/commentisfree/2018/may/13/we-created-poverty-algorithms-wont-make-that-go-away)
   * [Algorithms designed to fight poverty can actually make it worse](https://www.scientificamerican.com/article/algorithms-designed-to-fight-poverty-can-actually-make-it-worse/)
 * [What does it mean to 'solve' the problem of discrimination in hiring?](https://dl.acm.org/doi/abs/10.1145/3351095.3372849) - suggested by [@edwinrobots](https://www.informatik.tu-darmstadt.de/ukp/ukp_home/staff_ukp/index.en.jsp)
 * [Machine decisions and human consequences](https://arxiv.org/abs/1811.06747)
 * [Fairness and utilization in allocating resources with uncertain demand](https://dl.acm.org/doi/abs/10.1145/3351095.3372847) - suggested by [@edwinrobots](https://www.informatik.tu-darmstadt.de/ukp/ukp_home/staff_ukp/index.en.jsp)
-* [Algorithmic Injustices: Towards a relational ethics](https://arxiv.org/abs/1912.07376) - suggested by [@RobertArbon](https://github.com/RobertArbon), [:white_check_mark: 3rd March 2021](meetings/2021/03-march/03-03-21_meeting.md)
 * [Hacking the cis-tem](https://ieeexplore.ieee.org/document/8634814)
 
-#### Privacy and surveillance
+* [Measuring the predictability of life outcomes with a scientific mass collaboration](https://www.pnas.org/content/117/15/8398) - [#3](../../issues/3) - suggested by [@ninadicara](https://github.com/ninadicara)
+
+### Environmental costs and considerations
+
+* [Which programming languages use the least electricity?](https://thenewstack.io/which-programming-languages-use-the-least-electricity/)
+
+### Privacy and surveillance
+
 * [Privacy is power](https://www.politico.eu/article/privacy-is-power-opinion-data-gdpr/)
 * [Paths to Social License for Tracking-data Analytics](https://psyarxiv.com/9nye8/)
 
-#### Research Culture
+### Data ethics in the private and public sectors
+
+* [Google's AI principles](https://blog.google/technology/ai/ai-principles/) - suggested by [@milliams](http://milliams.com)
+* [The Financial Modelers Manifesto](https://www.uio.no/studier/emner/sv/oekonomi/ECON4135/h09/undervisningsmateriale/FinancialModelersManifesto.pdf) - [#2](../../issues/2) - suggested by [@ninadicara](https://github.com/ninadicara)
+  * Related: [A hippocratic oath for data science](https://virginia-eubanks.com/2018/02/21/a-hippocratic-oath-for-data-science/) - suggested by [@ninadicara](https://github.com/ninadicara)
+* [Artificial intelligence and transparency in the public sector](https://blog.burges-salmon.com/post/102gnvk/artificial-intelligence-and-transparency-in-the-public-sector) - suggested by [Tom Whittaker](https://blog.burges-salmon.com/u/102g2vz/tom-whittaker)
+
+* [Owning Ethics: Corporate Logics, Silicon Valley, and the Institutionalization of Ethics](https://muse.jhu.edu/article/732185) 
+
+### Research culture
+
+* [Towards Decolonising Computional Science](https://arxiv.org/abs/2009.14258) - suggested by [@nataliethurlby](https://github.com/NatalieThurlby)
+* 📺[Algorithmic Colonialisation](https://ethics.fast.ai/videos/?lesson=9) suggested by @ninadicara
+
 * [#bropenscience is Broken Science](https://thepsychologist.bps.org.uk/volume-33/november-2020/bropenscience-broken-science) - suggested by [@nataliethurlby](https://github.com/NatalieThurlby)
 * [Collectors, Allies, and Nightlights, Oh My](https://www.wpcjournal.com/article/view/20275) - suggested by [@nataliethurlby](https://github.com/NatalieThurlby)
 * [The Tyranny of Structurelessness](https://www.jofreeman.com/joreen/tyranny.htm) - suggested by [@nataliethurlby](https://github.com/NatalieThurlby)
@@ -89,40 +120,40 @@ We welcome suggestions for new categories, or moving materials between categorie
 * [Whiteness In Statistics](https://joelemartinez.com/2016/12/28/whiteness-in-statistics/) - suggested by [@NatalieThurlby](https://github.com/NatalieThurlby)
 * [Why Open Source misses the point of Free Software](https://www.gnu.org/philosophy/open-source-misses-the-point.en.html) 
 
+### Ethics in action
+
+* [A toolkit for centering racial equity throughout data integration](https://www.aecf.org/resources/a-toolkit-for-centering-racial-equity-within-data-integration/)<sup>1</sup>
+
+* [Design Justice: Towards an Intersectional Feminist Framework for Design Theory and Practice](https://designjustice.org/s/SSRN-id3189696.pdf)
+
+* [Data Feminism Book Club](https://datafeminism.io/blog/book/data-feminism-reading-group/)<sup>1</sup>
+  * Chapter 7: "Show your work"
+  * The description of "co-liberatory" projects in chapter 5: "Unicorns, janitors, ninjas, wizards and rock stars" 
+
+### Field Specific
+
+#### Natural Language Processing (NLP)
+
+* [On the Dangers of Stochastic Parrots: Can Language Models Be Too Big?](http://faculty.washington.edu/ebender/papers/Stochastic_Parrots.pdf) - suggested by [@ninadicara](https://github.com/ninadicara) - :white_check_mark: [17th February 2021](./meetings/2021/02-feb/17-02-21_meeting.md)
+* [Mitigating Gender Bias in Natural Language Processing: Literature Review](https://arxiv.org/abs/1906.08976) - suggested by [@NatalieThurlby](https://github.com/NatalieThurlby)
+* [Social Biases in NLP Models as Barriers for Persons with Disabilities](https://arxiv.org/pdf/2005.00813.pdf)
+* [Man is to Computer Programmer as Woman is to Homemaker? Debiasing Word Embeddings](https://arxiv.org/pdf/1607.06520.pdf) - suggested by [@leriomaggio](https://github.com/leriomaggio)
+  * Follow-up paper: [Lipstick on a Pig: Debiasing Methods Cover up Systematic Gender Biases in Word Embeddings But do not Remove Them](https://arxiv.org/abs/1903.03862) - suggested by [@NatalieThurlby](https://github.com/NatalieThurlby)
+* [Semantics derived automatically from language corpora contain human-like biases](https://science.sciencemag.org/content/sci/356/6334/183.full.pdf) - suggested by[@alicesaunders](https://github.com/alicesaunders)
+* [Gender Bias and Sexism in Language](https://oxfordre.com/communication/view/10.1093/acrefore/9780190228613.001.0001/acrefore-9780190228613-e-470#acrefore-9780190228613-e-470-bibItem-0028) - suggested by [@leriomaggio](https://github.com/leriomaggio)
+
+#### Computer vision
+
+* 📺 [How normal am I?](https://www.hownormalami.eu/) - interactive - suggested by Valentina Ragni
+
+* 📺 [Critical perspectives on computer vision](https://slideslive.com/38923500/critical-perspectives-on-computer-vision)  - suggested by [@NatalieThurlby](https://github.com/NatalieThurlby)
+
 #### Explainable AI/ML
-* [Explainable machine learning: how can you determine what a party knew or intended when a decision was made by machine-learning?
-](https://www.scl.org/articles/12130-explainable-machine-learning-how-can-you-determine-what-a-party-knew-or-intended-when-a-decision-was-made-by-machine-learning) - suggested by [Tom Whittaker](https://blog.burges-salmon.com/u/102g2vz/tom-whittaker)
+
+* [Explainable machine learning: how can you determine what a party knew or intended when a decision was made by machine-learning?](https://www.scl.org/articles/12130-explainable-machine-learning-how-can-you-determine-what-a-party-knew-or-intended-when-a-decision-was-made-by-machine-learning) - suggested by [Tom Whittaker](https://blog.burges-salmon.com/u/102g2vz/tom-whittaker)
 * [Explainable Artificial Intelligence (XAI): Concepts, taxonomies, opportunities and challenges toward responsible AI](https://www.sciencedirect.com/science/article/pii/S1566253519308103?casa_token=1cYbsG99NNAAAAAA:4FsE_4ZQI72ZSA-SbawjNiEkhY5zIDjChANdTKxJ8Qy8RiCCQ0ztFye-rdQ98MeO9RY3_8Nw) - suggested by [@NatalieThurlby](https://github.com/NatalieThurlby)
 
-#### Unsorted
-* [Towards Decolonising Computional Science](https://arxiv.org/abs/2009.14258) - suggested by [@nataliethurlby](https://github.com/NatalieThurlby)
-* [Google's AI principles](https://blog.google/technology/ai/ai-principles/) - suggested by [@milliams](http://milliams.com)
-* [Ethical principles in machine learning and artificial intelligence: cases from the field and possible ways forward](https://www.nature.com/articles/s41599-020-0501-9) 
-* [Introduction to Research Ethics](https://the-turing-way.netlify.app/ethical-research/ethics-intro.html) - suggested by [@leriomaggio](https://github.com/leriomaggio)
-* [Design Justice: Towards an Intersectional Feminist Framework for Design Theory and Practice](https://designjustice.org/s/SSRN-id3189696.pdf)
-* [A toolkit for centering racial equity throughout data integration](https://www.aecf.org/resources/a-toolkit-for-centering-racial-equity-within-data-integration/)<sup>1</sup>
-* [Measuring the predictability of life outcomes with a scientific mass collaboration](https://www.pnas.org/content/117/15/8398) - [#3](../../issues/3) - suggested by [@ninadicara](https://github.com/ninadicara)
-* [What is Data Ethics?](https://royalsocietypublishing.org/doi/10.1098/rsta.2016.0360)<sup>1</sup>
-* [The Financial Modelers Manifesto](https://www.uio.no/studier/emner/sv/oekonomi/ECON4135/h09/undervisningsmateriale/FinancialModelersManifesto.pdf) - [#2](../../issues/2) - suggested by [@ninadicara](https://github.com/ninadicara)
-* [The Missing Datasets Project](https://github.com/MimiOnuoha/missing-datasets) - [#1](../../issues/1) - suggested by [@ninadicara](https://github.com/ninadicara)
-* [Which programming languages use the least electricity?](https://thenewstack.io/which-programming-languages-use-the-least-electricity/)
-* [Ethics can't be a side hustle](https://deardesignstudent.com/ethics-cant-be-a-side-hustle-b9e78c090aee) - :white_check_mark: [3rd Feb 2021](./meetings/2021/02-feb/03-02-21_meeting.md)
-* [Reflections on trusting trust](http://users.ece.cmu.edu/~ganger/712.fall02/papers/p761-thompson.pdf)
-* [Why data is never raw](https://www.thenewatlantis.com/publications/why-data-is-never-raw)
-* [Ethical data science](https://arxiv.org/pdf/1411.1373.pdf)<sup>1</sup>
-* [Owning Ethics: Corporate Logics, Silicon Valley, and the Institutionalization of Ethics](https://muse.jhu.edu/article/732185) 
-* [Dataism is our new God](https://onlinelibrary.wiley.com/doi/pdf/10.1111/npqu.12080?casa_token=cj8N7zTKYeIAAAAA:fiV6jUDL9dVhZ5oADoLszgzL5Ubn5NWCmLuO6mVxa_mf_sO-JEB6nU-9FP5fYL5pm8JisxYlWEe) - suggested by [@NatalieThurlby](https://github.com/NatalieThurlby)
 
-### Suggestions for viewing/listening/experiencing
-* [Critical perspectives on computer vision](https://slideslive.com/38923500/critical-perspectives-on-computer-vision)  - suggested by [@NatalieThurlby](https://github.com/NatalieThurlby)
-* [Data Feminism Book Club](https://datafeminism.io/blog/book/data-feminism-reading-group/)<sup>1</sup>
-    * Chapter 7: "Show your work"
-    * The description of "co-liberatory" projects in chapter 5: "Unicorns, janitors, ninjas, wizards and rock stars" 
-* [AI, Ain’t I a Woman?](https://www.youtube.com/watch?v=HZxV9w2o0FM) - poem<sup>2</sup> - suggested by Valentina Ragni
-* [How normal am I?](https://www.hownormalami.eu/) - interactive - suggested by Valentina Ragni
-* [Fast AI Practical Data Ethics lecture series](https://ethics.fast.ai/)<sup>1</sup>
-    * [Lesson 6 - Algorithmic Colonialisation](https://ethics.fast.ai/videos/?lesson=9)
-* [21 Fairness Definitions and their politics](https://www.youtube.com/watch?v=jIXIuYdnyyk) - suggested by [@NatalieThurlby](https://github.com/NatalieThurlby)
 
 ### Key
 - [1]: A longer piece of work, we'd need to choose a chapter or section.


### PR DESCRIPTION
I've had a go a reorganising the reading list.

Changes: 
- Added some new categories
- Added an umbrella category for specific data science subfields like NLP, Explainable AI, Computer Vision
- Integrated the Watch/Listen subsection into the main list, where watching materials are indicated by a 📺 icon. 