### PR TITLE
Update reading list to include 'Economies of Virtue'

### DIFF
--- a/site/contents/reading-list.md
+++ b/site/contents/reading-list.md
@@ -116,6 +116,7 @@ Note: reading materials appear once in the category we felt they fit best.
 * [Whiteness In Statistics](https://joelemartinez.com/2016/12/28/whiteness-in-statistics/) - suggested by [@NatalieThurlby](https://github.com/NatalieThurlby)
 * [Why Open Source misses the point of Free Software](https://www.gnu.org/philosophy/open-source-misses-the-point.en.html) 
 * [Ethics Creep](https://link.springer.com/article/10.1023/B:Quas.0000049239.15922.a3)🔒 - suggested by [@NatalieThurlby](https://github.com/NatalieThurlby)
+* [Economies of Virtue: The Circulation of ‘Ethics’ in Big Tech](https://doi.org/10.1080/09505431.2021.1990875) - suggested by [@RShkunov](https://twitter.com/RShkunov)
 
 ## Ethics in action (the good and the not so good)
 


### PR DESCRIPTION
Added "Economies of Virtue: The Circulation of ‘Ethics’ in Big Tech" to reading list - this is an article about how ethics becomes a form of capital produced by academics etc that is then taken up by Big Tech