### PR TITLE
Add license footer

### DIFF
--- a/site/_templates/license-footer.html
+++ b/site/_templates/license-footer.html
@@ -1,0 +1,1 @@
+License: <a href="https://creativecommons.org/licenses/by/4.0/">CC-BY-4.0</a>

--- a/site/conf.py
+++ b/site/conf.py
@@ -59,6 +59,7 @@ html_theme_options = {
     'twitter_url': 'https://twitter.com/hashtag/DataEthicsClub',
     'search_bar_text': 'Search this site...',
     'show_prev_next': True,
+    'footer_items': ['license-footer', 'sphinx-version'],
 }
 
 html_sidebars = {


### PR DESCRIPTION
Closes #108 by copying the Data Hazards website style for the footer - this states the license is CC-BY-4.0 and links to the creative commons website, instead of saying the copy right belongs to us. 
