### PR TITLE
Move main meeting info to Join In

### DIFF
--- a/site/join_in/join_in.md
+++ b/site/join_in/join_in.md
@@ -19,21 +19,23 @@ Please read our [Code of Conduct](code-of-conduct) before attending.
 
 ## Upcoming meetings
 
-These are the meetings for the next academic term. 
-We will update the material and questions based on the previous weeks' vote. 
+These are the meetings for the next academic term.  
+We will update the material and questions based on the previous weeks' vote.  
 
-All meetings are held at 1pm **UK** time.
-If you are in another timezone please [use a time/date converter like this one to check your local time](https://www.timeanddate.com/worldclock/converter.html)! 
+All meetings are held at 1pm **UK** time.  
+If you are in another timezone please [use a time/date converter like this one to check your local time](https://www.timeanddate.com/worldclock/converter.html)!  
 
-[You can see the write ups of previous meetings here!](../write_ups/write-ups)
+Join the meeting on the following Zoom link: https://bristol-ac-uk.zoom.us/j/96026442410  
+
+[You can see the write ups of previous meetings here!](../write_ups/write-ups)  
 
 ### 25th September
 Material: [ChatGPT is Bullsh*t](https://link.springer.com/article/10.1007/s10676-024-09775-5)
 
 Discussion questions: 
-1) Do you think that the labels of ChatGPT as a bullshit machine is fair?
-2) Do you think ChatGPT is a soft or a hard bullshitter? I.e. do you think it has the intention to mislead its audience or not?
-3) What do you think of the implications of the anthropomorphizing of AI tools? E.g. hallucination, learning, training, perception etc.
+1) Do you think that the labels of ChatGPT as a bullshit machine is fair?  
+2) Do you think ChatGPT is a soft or a hard bullshitter? I.e. do you think it has the intention to mislead its audience or not?  
+3) What do you think of the implications of the anthropomorphizing of AI tools? E.g. hallucination, learning, training, perception etc.  
 
 ### 9th October
 To be decided.

--- a/site/join_in/join_in.md
+++ b/site/join_in/join_in.md
@@ -17,18 +17,47 @@ If you would like to get email reminders about the content and dates for the nex
 
 Please read our [Code of Conduct](code-of-conduct) before attending.
 
-
 ## Upcoming meetings
-| Date (dd.mm.yyyy, UK time)                            | Discussion Material |
-|--------------------------------------------------------|---------------------|
-| Weekly in July/August 2024 | [Data Feminism Book Club](meetings/2024/data-feminism) |
+
+These are the meetings for the next academic term. 
+We will update the material and questions based on the previous weeks' vote. 
+
+All meetings are held at 1pm **UK** time.
+If you are in another timezone please [use a time/date converter like this one to check your local time](https://www.timeanddate.com/worldclock/converter.html)! 
+
+[You can see the write ups of previous meetings here!](../write_ups/write-ups)
+
+### 25th September
+Material: [ChatGPT is Bullsh*t](https://link.springer.com/article/10.1007/s10676-024-09775-5)
+
+Discussion questions: 
+1) Do you think that the labels of ChatGPT as a bullshit machine is fair?
+2) Do you think ChatGPT is a soft or a hard bullshitter? I.e. do you think it has the intention to mislead its audience or not?
+3) What do you think of the implications of the anthropomorphizing of AI tools? E.g. hallucination, learning, training, perception etc.
+
+### 9th October
+To be decided.
+
+### 23rd October
+To be decided.
+
+### 6th November - DEC Special!
+To be decided.
+
+### 20th November
+To be decided.
+
+### 4th December
+To be decided.
+
 
 ## Past Meetings
 
 You can see a record of what we have discussed previously here.
 | Date | Discussion Material | Summary |
 |-------------------|---------------------|---------------------|
-| [04.06.2024](meetings/2024/06-jun/04-06-24_meeting.md), 11am | [How AI Could Save (Not Destroy) Education](https://www.youtube.com/watch?v=hJP5GqnTrNo) |[Read the writeup](https://dataethicsclub.com/write_ups/2024-06-04_writeup.html)|
+| Weekly in July/August 2024 | [Data Feminism Book Club](meetings/2024/data-feminism) | TBD |
+| [04.06.2024](meetings/2024/06-jun/04-06-24_xmeeting.md), 11am | [How AI Could Save (Not Destroy) Education](https://www.youtube.com/watch?v=hJP5GqnTrNo) |[Read the writeup](https://dataethicsclub.com/write_ups/2024-06-04_writeup.html)|
 | [22.05.2024](meetings/2024/05-may/22-05-24_meeting.md), 1pm | [The Myers-Briggs Test Has Been Debunked Time and Again. Why Do Companies Still Use It?](https://dataethicsclub.com/join_in/meetings/2024/05-may/22-05-24_meeting.html) | [Read the writeup](https://dataethicsclub.com/write_ups/2024-05-22_writeup.html) |
 | [08.05.2024](meetings/2024/05-may/08-05-24_meeting.md), 1pm | [Amazon's Just Walk Out technology relies on hundreds of workers in India watching you shop](https://www.businessinsider.com/amazons-just-walk-out-actually-1-000-people-in-india-2024-4) | [Read the writeup](https://dataethicsclub.com/write_ups/2024-05-08_writeup.html) | 
 | [24.04.2024](meetings/2024/04-apr/24-04-24_meeting.md), 1pm | [Artificial Intelligence Act: MEPs adopt landmark law](https://www.europarl.europa.eu/news/en/press-room/20240308IPR19015/artificial-intelligence-act-meps-adopt-landmark-law) | [Read the writeup](https://dataethicsclub.com/write_ups/2024-04-24_writeup.html) |

--- a/site/join_in/meetings/2024/data-feminism.md
+++ b/site/join_in/meetings/2024/data-feminism.md
@@ -1,6 +1,6 @@
 # Data Feminism Book Club 2024
 
-__What are we reading?__ [Data Feminism by Catherine D'Ignazio and Laura F. Klein](https://mitpress.mit.edu/9780262547185/data-feminism/)
+__What are we reading?__ [Data Feminism by Catherine D'Ignazio and Lauren F. Klein](https://mitpress.mit.edu/9780262547185/data-feminism/)
 
 We will be holding weekly meetings over the summer to help us all stay accountable and to discuss
 our thoughts on _Data Feminism_ - a classic data ethics text that many of us have probably had on our
@@ -43,10 +43,3 @@ This is to try and get the best coverage across requested timezones which were: 
 | Pacific Daylight Time UTC-7 | 07:00              |
 
 Psst - Please raise an issue if you spot that any of these time conversions are incorrect! 
-
-
-
-## Want to join? 
-
-We'd love to have you join! Email Nina at nina.dicara@bristol.ac.uk if you'd like to go on the email list for meeting reminders over the summer. 
-We can also send you a calendar invite for the events if you like so they're in your online diary.

--- a/site/join_in/meetings/2024/data-feminism.md
+++ b/site/join_in/meetings/2024/data-feminism.md
@@ -6,8 +6,66 @@ We will be holding weekly meetings over the summer to help us all stay accountab
 our thoughts on _Data Feminism_ - a classic data ethics text that many of us have probably had on our
 `to read` lists for too long!  
 
-Remember you will need to get yourself a copy of the book. 
-If you need help finding a copy then email Nina at nina.dicara@bristol.ac.uk. 
+**Update - we had a brilliant time reading this book! We've included the questions we used for our discussions below in case they are useful to anyone else organising a similar group.**
+
+## Discussion Questions
+### Introduction
+
+First we did an activity to introduce ourselves called
+'The Story of My Name'. 
+[Find the instructions on how to run this activity here](https://onehe.org/eu-activity/introductions-story-of-your-name/). 
+We went into breakout rooms of 5-ish people to do this, but on reflection could have done it with up to 20 people in the main room. 
+
+Then we discussed: 
+- What brings you to the reading group?  
+- What does feminism mean to you?  
+
+### Chapter 1 - The Power Chapter
+
+- Have you seen the Matrix of Domination before? What did you think - do you feel you understand it?  
+- The chapter outlines issues with under-representation in data, and over-representation. What are your thought on the tensions between these?  
+- In your current role, or examples from your personal life, how does data play in? Who does it benefit - and does it align with the science, surveillance, selling groups?  
+
+### Chapter 2 - Collect, Analyze, Imagine, Teach
+
+- Have you heard of 'counterdata' before - how might it apply in your areas of lived experience or expertise?  
+- Imagine - what would it look like to be a Data Justice Club, rather than a Data Ethics Club? (See Table 2.1)
+- What would need to change for projects like Local Lotto to be used more in teaching data skills?
+
+### Chapter 3 - On Rational, Scientific, Objective Viewpoints from Mythical, Imaginary, Impossible Standpoints
+
+- What does it mean to you to 'Elevant Emotion and Embodiment' in data visualisation and/or data generally?  
+- What did you think of the examples of how positionality is expressed in data visualisations (intended or not) using different graph styles, colour or annotations - do you have any reflections from your personal context?
+- What did you think of the reactions of NYT readers to the election gauge? How should we represent uncertainty?
+
+### Chapter 4 - "What Gets Counted Counts"
+
+- How can we make sure we are using classification when its needed, but not enforcing unnecessary distinctions when its not?  
+- Have you come across the paradox of exposure before? Do you have examples of it being addressed well, or badly?
+- Do you have any good examples of quantitative data supporting qualitative data or vice versa?
+
+### Chapter 5 - Unicorns, Janitors, Ninjas, Wizards, and Rock Stars
+
+- In your career until now, have you come across stereotypes re: data analysts or working with data? To what degree do you think these hinder or support the work being done? How would you reframe the public image of the data analyst within your workplace to support the processes you would like to model?  
+- The distance between analyst/researcher and the data itself can introduce significant bias in the process of analysis. Sometimes in our jobs we do not have the scope to aim for co-liberation. Do you have any examples of what can be done to bridge this distance in our regular work processes?  
+- When thinking of co-liberation as the end goal of data analysis, which parts of the process do you find least intuitive to model for this outcome? Do you have examples of processes where you have strived for data for good or co-liberation?  
+
+### Chapter 6 - The Numbers Don’t Speak for Themselves
+
+- What problems does big data solve versus create?
+- What are your thoughts on how we label graphs with context?
+- Where does responsibility lie for proving data context in your area?  How does funding play in?  
+
+### Chapter 7 - Show Your Work
+
+- What other products' hidden labor would you like to see mapped like the Amazon Echo in Anatomy of an AI system?
+- Do you have any examples of invisible labor that you do in your work?  
+- How do you think invisible labor should be communicated? Could we do anything differently?  
+
+### Conclusion - Now Let's Multiply
+
+- What is your favourite new definition/thing you've learned about from the book?
+- Is there anything you plan to do differently on the basis of what we've read?  
 
 ## Meeting Dates and Times 
 

--- a/site/join_in/meetings/next-meeting.md
+++ b/site/join_in/meetings/next-meeting.md
@@ -1,1 +1,1 @@
-<meta http-equiv="refresh" content="0; url=2024/data-feminism.html" />
+<meta http-equiv="refresh" content="0; url=join_in.html#upcoming-meetings" />


### PR DESCRIPTION
This PR reduces the amount of admin required to keep the website up to date - now the 'Next Meeting' will always resolve to the Join In page rather than having to change it to the next meeting page every time. The Join In page will contain the upcoming content and questions, and we will phase out the use of the 'Meeting' pages to reduce admin. 
This will give people the same information but only require updating Join In each week :) 